### PR TITLE
Bump IridiumColorAPI to 1.0.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
         <dependency>
             <groupId>com.iridium</groupId>
             <artifactId>IridiumColorAPI</artifactId>
-            <version>1.0.4</version>
+            <version>1.0.5</version>
         </dependency>
         <dependency>
             <groupId>me.mattstudios.utils</groupId>


### PR DESCRIPTION
This allows users to use the `#{HEX}` syntax for RGB colors, which was requested by one of your users.