### PR TITLE
Fix typo in message of /rsb command

### DIFF
--- a/src/main/java/josegamerpt/realscoreboard/Commands.java
+++ b/src/main/java/josegamerpt/realscoreboard/Commands.java
@@ -18,7 +18,7 @@ public class Commands extends CommandBase {
     @Default
     public void defaultCommand(final CommandSender commandSender) {
         Text.send(commandSender, Arrays.asList("&7", Text.getPrefix() + "&a" + RealScoreboard.getInstance().getVersion() + " &bHelp",
-                "&f/rsw toggle"));
+                "&f/rsb toggle"));
     }
 
     @SubCommand("reload")


### PR DESCRIPTION
Fixed a typo where the message from the '/rsb' command would show '/rsw toggle' which does not exist