### PR TITLE
ItemAdder Support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>josegamerpt.realscoreboard</groupId>
     <artifactId>RealScoreboard</artifactId>
-    <version>12-08-2022 Build 1</version>
+    <version>14-08-2022 Build 1</version>
     <packaging>jar</packaging>
 
     <name>RealScoreboard</name>
@@ -35,7 +35,7 @@
                     <relocations>
                         <relocation>
                             <pattern>me.mattstudios.mf</pattern>
-                            <shadedPattern>josegamerpt.realscoreboard.mf</shadedPattern> <!-- Replace package here here -->
+                            <shadedPattern>josegamerpt.realscoreboard.mf</shadedPattern>
                         </relocation>
                     </relocations>
                 </configuration>
@@ -61,6 +61,10 @@
         <repository>
             <id>sonatype</id>
             <url>https://oss.sonatype.org/content/groups/public/</url>
+        </repository>
+        <repository>
+            <id>spigot-repo</id>
+            <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
         </repository>
         <repository>
             <id>jitpack.io</id>
@@ -98,6 +102,12 @@
             <groupId>me.clip</groupId>
             <artifactId>placeholderapi</artifactId>
             <version>2.11.2</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.spigotmc</groupId>
+            <artifactId>spigot-api</artifactId>
+            <version>1.18.2-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/josegamerpt/realscoreboard/config/Configer.java
+++ b/src/main/java/josegamerpt/realscoreboard/config/Configer.java
@@ -7,7 +7,7 @@ import java.util.Collections;
 
 public class Configer {
 
-    private final static int latest = 12;
+    private final static int latest = 13;
     private static String errors;
 
     public static int getConfigVersion() {
@@ -91,6 +91,12 @@ public class Configer {
                 case 11:
                     newconfig = 12;
                     Config.file().set("Config.Check-for-Updates", true);
+                    Config.save();
+                    break;
+                case 12:
+                    newconfig = 13;
+                    Config.file().set("Version", newconfig);
+                    Config.file().set("Config.ItemAdder-Support", true);
                     Config.save();
                     break;
             }

--- a/src/main/java/josegamerpt/realscoreboard/scoreboard/ScoreboardTask.java
+++ b/src/main/java/josegamerpt/realscoreboard/scoreboard/ScoreboardTask.java
@@ -6,6 +6,7 @@ import josegamerpt.realscoreboard.config.PlayerData;
 import josegamerpt.realscoreboard.iridumapi.IridiumAPI;
 import josegamerpt.realscoreboard.scoreboard.fastscoreboard.FastBoard;
 import josegamerpt.realscoreboard.utils.Text;
+import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitRunnable;
 
@@ -28,8 +29,7 @@ public class ScoreboardTask extends BukkitRunnable {
 
     @Override
     public void run() {
-        if (!this.player.isOnline())
-        {
+        if (!this.player.isOnline()) {
             this.cancel();
             return;
         }
@@ -54,6 +54,26 @@ public class ScoreboardTask extends BukkitRunnable {
                 return IridiumAPI.process(s);
             }).collect(Collectors.toList());
 
+            if (Config.file().getBoolean("Config.ItemAdder-Support")) {
+                list = list.stream().map(s -> {
+                    StringBuilder stringBuilder = new StringBuilder();
+                    String[] split = s.split(" ");
+                    for (int i = 0; i < split.length; i++) {
+                        String space = " ";
+                        if (i == split.length - 1) space = "";
+                        String splitWord = split[i];
+                        String[] splitWordSplit = splitWord.split(":");
+                        if (splitWordSplit.length < 2) {
+                            stringBuilder.append(splitWord).append(space);
+                            continue;
+                        }
+                        stringBuilder.append("§f%img_").append(splitWordSplit[1]).append("%").append(space);
+                    }
+                    return rs.getPlaceholders().setPlaceHolders(player, stringBuilder.toString());
+                }).collect(Collectors.toList());
+            }
+
+
             String title = rsb.getTitle();
             if (Config.file().getBoolean("Config.Use-Placeholders-In-Scoreboard-Titles")) {
                 title = this.rs.getPlaceholders().setPlaceHolders(this.player, title);
@@ -61,7 +81,8 @@ public class ScoreboardTask extends BukkitRunnable {
 
             this.fastBoard.updateTitle(IridiumAPI.process(title));
             this.fastBoard.updateLines(list);
-        } catch (Exception e) {
+        } catch (
+                Exception e) {
             rs.getLogger().log(Level.SEVERE, "[ERROR] RealScoreboard threw an error while trying to display the scoreboard for " + this.player.getName());
             e.printStackTrace();
         }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,5 +1,6 @@
 Debug: false
 Config:
+  ItemAdder-Support: true
   Check-for-Updates: true
   Prefix: '&bReal&9Scoreboard &7| &r'
   Reloaded: '&fThe config has been &areloaded&f.'


### PR DESCRIPTION
This will parse the the placeholders of ItemAdder in order to work with RealScoreboard.

It will just replace, for example, :admin: to %img_admin% and apply the placeholders again. This feature can also be disabled within the config file.

`ItemAdder-Support: true`